### PR TITLE
node engine: node 7 is now out

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "6"
+    "node": ">=6"
   },
   "scripts": {
     "test": "npm run test-unit && npm run test-coverage",


### PR DESCRIPTION
The installation fails with `yarn` if the current used node version is 7. And Node 7 is out since 2 weeks.

I assumed that version 6 and above are compatible.