### PR TITLE
fix object arrays

### DIFF
--- a/src/lib/env.getOrElseAll.test.js
+++ b/src/lib/env.getOrElseAll.test.js
@@ -62,7 +62,18 @@ describe('.getOrElseAll', function() {
           ok: {
             heyheyhey: true
           }
-        }
+        },
+        exchanges: [
+          {
+            name: 'exchange.one',
+            type: 'topic',
+            durable: true
+          }, {
+            name: 'exchange.one.dead',
+            type: 'topic',
+            durable: true
+          }
+        ]
       },
 
       a: {
@@ -108,6 +119,17 @@ describe('.getOrElseAll', function() {
     t.strictEqual(config.AMQP.PLOP.ok.heyheyhey, true);
     t.strictEqual(config.AMQP.connect, true);
     t.strictEqual(config.AMQP.connect2, false);
+    t.deepEqual(config.AMQP.exchanges, [
+      {
+        name: 'exchange.one',
+        type: 'topic',
+        durable: true
+      }, {
+        name: 'exchange.one.dead',
+        type: 'topic',
+        durable: true
+      }
+    ]);
 
     t.deepEqual(config.a.b.c.f, ['a', 'c', 'd']);
     t.deepEqual(config.a.b.c.fOverride, 'hello'.split(''));

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -106,6 +106,8 @@ module.exports = function envFactory() {
         .max()
         .value() || 0;
 
+      // we want to at least map all config defined elements
+      // so we choose the greater index between config defined index and the env var defined one
       return Math.max(envMaxIndex, arrayValues.length - 1);
     }
 

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -91,7 +91,7 @@ module.exports = function envFactory() {
      * @return {[type]}                  [description]
      */
     function getMaxIndex(envKeyNamePrefix, env) {
-      return _.chain(env)
+      var envMaxIndex = _.chain(env)
         .toPairs()
         // only keep keys that are in the format {envKeyNamePrefix}__{NUMBER}[....] (because it can either be an array of array or an array of other objects)
         .filter(([envKey, envVal], k) => {
@@ -105,6 +105,8 @@ module.exports = function envFactory() {
         })
         .max()
         .value() || 0;
+
+      return Math.max(envMaxIndex, arrayValues.length - 1);
     }
 
     return _.range(0, getMaxIndex(context.fullKeyName, process.env) + 1).map(function(___, index) {


### PR DESCRIPTION
Rigth now, object arrays are filtered to their first element when no env variable is defined.
An object array of 10 elements for witch the greater env var index of 5 is defined will be truncated to 6 elements.