### PR TITLE
Update Lodash to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "updtr": "^0.2.1"
   },
   "dependencies": {
-    "lodash": "^4.15.0"
+    "lodash": "^4.17.11"
   }
 }


### PR DESCRIPTION
Because https://david-dm.org/FGRibreau/common-env says `4.15.0` has a flaw and `4.17.10` brings better Node.js 10 support (https://github.com/lodash/lodash/wiki/Changelog#v41710)